### PR TITLE
adding test for checking broken links

### DIFF
--- a/test/e2e/test_edge-cases.py
+++ b/test/e2e/test_edge-cases.py
@@ -1,0 +1,9 @@
+from playwright.sync_api import Page, expect
+
+"""
+Checking for broken tag links with spaces in them
+"""
+def test_tag_broken_link_spaces(page: Page):
+    page.goto("/show/linux-unplugged/489/")
+    page.locator(".tag > a", has_text="linux unplugged").click()
+    expect(page.locator(".title", has_text="Tag: linux unplugged")).to_be_visible()


### PR DESCRIPTION
Hey @Balastrong, to help ensure we don't have a regression on this bugfix I created a test for this specific use case.

If you don't mind accepting this PR, into your current PR this will help when I accept your PR (which everything looks good to me (LGTM)) and will help for future PRs + features.

I specifically used the tag which was shown in the issue (https://github.com/JupiterBroadcasting/jupiterbroadcasting.com/issues/497), so we had an exact test for the bug which was filed.

---

Here is an example of me running the test locally for the develop branch (which currently fails because it doesn't have your fix): 
![image](https://user-images.githubusercontent.com/10230166/221394585-253ad592-c8ff-45b0-8083-ea9f6c0cd05b.png)

---

Here's a screen recording show the test run visually:

[jb-showing_test.webm](https://user-images.githubusercontent.com/10230166/221395143-7ce18e90-66ac-435a-8aaf-273ae1685eb4.webm)

---

Then this is when I run it against your branch and how it passes:
![image](https://user-images.githubusercontent.com/10230166/221394777-a5fe18ee-3397-45a9-ae9b-cc7abe962c19.png)

